### PR TITLE
jar file download and image build in snakemake

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,22 +53,9 @@ Format to universal output.
 
 
 # JADBio
-### One Time Setup
-Download requires access to Synapse project page.
-```
-# Get jar file from Synapse
-cd jadbio
-synapse get -r syn27367851 --downloadLocation src/
-```
-
-### Manually Build Docker Image for JADBio
-```
-cd jadbio
-docker build -t jadbio .
-````
-
 ### Run Model for Predicted Subtypes
 ```
+cd jadbio
 bash RUN.sh
 ```
 

--- a/Snakefile
+++ b/Snakefile
@@ -42,7 +42,7 @@ rule cloudforest:
 
 rule jadbio_java:
     output:
-        "jadbio-model-exe.jar"
+        "jadbio/src/jadbio-model-exe.jar"
     shell:
         "synapse get -r syn27367851 --downloadLocation jadbio/src/"
 
@@ -50,6 +50,6 @@ rule jadbio_docker_load:
     output:
         "jabio.info"
     input:
-        "jadbio-model-exe.jar"
+        "jadbio/src/jadbio-model-exe.jar"
     shell:
         "docker build -t jadbio . && docker images | grep jadbio > jadbio.info"

--- a/Snakefile
+++ b/Snakefile
@@ -39,3 +39,17 @@ rule cloudforest:
         "cloudforest.info"
     shell:
         "docker build -t cloudforest cloudforest/ && docker images | grep cloudforest > cloudforest.info"
+
+rule jadbio_java:
+    output:
+        "jadbio-model-exe.jar"
+    shell:
+        "synapse get -r syn27367851 --downloadLocation jadbio/src/"
+
+rule jadbio_docker_load:
+    output:
+        "jabio.info"
+    input:
+        "jadbio-model-exe.jar"
+    shell:
+        "docker build -t jadbio . && docker images | grep jadbio > jadbio.info"


### PR DESCRIPTION
Add JADBio java file download and docker image build into snakelike pipeline. updates to README documentation to reflect these changes.