### PR TITLE
Aklimate platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,12 @@ bash RUN.sh
 
 
 # AKLIMATE
-### Build image with permissions updated
-```
-cd aklimate
-docker build --tag aklimate2 .
-```
+Allowed platform types: TOP, MULTI, GEXP, CNVR, or METH
+No models for MIR or MUTA for any cancer cohorts. No models for ACC GEXP, BRCA METH, OV MULTI, PAAD GEXP, SKCM CNVR, or UVM GEXP.
+
 ### Run Model for Predicted Subtypes
 ```
-# Predict subtypes
+cd aklimate
 bash RUN.sh
 ```
 

--- a/Snakefile
+++ b/Snakefile
@@ -24,17 +24,17 @@ rule subscope_docker_load:
 
 rule aklimate_docker:
     output:
-        "aklimate/src/stuartlab_tmp_aklimate_20210714_docker_image.tar.gz"
+        "aklimate/src/stuartlab_tmp_aklimate_20220407_docker_image.tar.gz"
     shell:
-        "synapse get -r syn25982821 --downloadLocation aklimate/src/"
+        "synapse get -r syn29280221 --downloadLocation aklimate/src/"
 
 rule aklimate_docker_load:
     output:
         "aklimate.info"
     input:
-        "aklimate/src/stuartlab_tmp_aklimate_20210714_docker_image.tar.gz"
+        "aklimate/src/stuartlab_tmp_aklimate_20220407_docker_image.tar.gz"
     shell:
-        "docker load -i aklimate/src/stuartlab_tmp_aklimate_20210714_docker_image.tar.gz && docker tag 4befea59cb3b aklimate-tmp:latest && docker images | grep aklimate > aklimate.info"
+        "docker load -i aklimate/src/stuartlab_tmp_aklimate_20220407_docker_image.tar.gz && docker tag 881bb86c6cfd aklimate-tmp:latest && docker images | grep aklimate > aklimate.info"
 
 rule cloudforest:
     output:

--- a/aklimate/job_inputs/aklimate-inputs.yml
+++ b/aklimate/job_inputs/aklimate-inputs.yml
@@ -1,22 +1,24 @@
 ## Select one or more for each section ##
 
 # TCGA Cancer cohort
-#Allowed values are ACC, BLCA, BRCA, CESC, COADREAD, ESCC,
+# Options: ACC, BLCA, BRCA, CESC, COADREAD, ESCC,
 #GEA, HNSC, KIRCKICH, KIRP, LGGGBM, LIHCCHOL, LUAD, LUSC,
 #MESO, OV, PAAD, PCPG, PRAD, SARC, SKCM, TGCT, THCA, THYM,
 #UCEC, UVM.
 cancer:
   - "BRCA"
 
+
 # Data Platform (top model)
-#Allowed values are GEXP, CNVR, METH, MULTI, TOP.
+# Options: GEXP, CNVR, METH, MULTI, TOP.
 #TOP will select the model with the highest prediction performance in 5-fold cross validation.
 platform:
-  - 'GEXP'
+  - "TOP"
+
 
 # User Data
 #First row gives feature IDs.
 #First column gives sample IDs.
 input_data:
   - class: File
-    path: ../data/input/metabric_tmprescale.tsv
+    path: ../../example_inputs_cancers/example_BRCA.tsv

--- a/aklimate/job_inputs/aklimate-inputs.yml
+++ b/aklimate/job_inputs/aklimate-inputs.yml
@@ -1,7 +1,22 @@
+## Select one or more for each section ##
+
+# TCGA Cancer cohort
+#Allowed values are ACC, BLCA, BRCA, CESC, COADREAD, ESCC,
+#GEA, HNSC, KIRCKICH, KIRP, LGGGBM, LIHCCHOL, LUAD, LUSC,
+#MESO, OV, PAAD, PCPG, PRAD, SARC, SKCM, TGCT, THCA, THYM,
+#UCEC, UVM.
 cancer:
   - "BRCA"
 
+# Data Platform (top model)
+#Allowed values are GEXP, CNVR, METH, MULTI, TOP.
+#TOP will select the model with the highest prediction performance in 5-fold cross validation.
+platform:
+  - 'GEXP'
 
+# User Data
+#First row gives feature IDs.
+#First column gives sample IDs.
 input_data:
   - class: File
     path: ../data/input/metabric_tmprescale.tsv

--- a/aklimate/tools/aklimate-pred.cwl
+++ b/aklimate/tools/aklimate-pred.cwl
@@ -8,7 +8,7 @@ requirements:
       - $(inputs.input_data)
 hints:
   DockerRequirement:
-    dockerPull: "aklimate2"
+    dockerImageId: "aklimate-tmp"
 
 
 inputs:
@@ -16,11 +16,14 @@ inputs:
     type: string
     inputBinding:
       position: 1
-
+  platform:
+    type: string
+    inputBinding:
+      position: 2
   input_data:
     type: File
     inputBinding:
-      position: 2
+      position: 3
 
 
 outputs:

--- a/aklimate/workflows/ml_workflow.cwl
+++ b/aklimate/workflows/ml_workflow.cwl
@@ -4,7 +4,7 @@ cwlVersion: v1.0
 class: Workflow
 requirements:
   - class: DockerRequirement
-    dockerPull: "aklimate2"
+    dockerImageId: "aklimate-tmp"
   - class: ScatterFeatureRequirement
   - class: StepInputExpressionRequirement
   - class: SubworkflowFeatureRequirement
@@ -12,12 +12,12 @@ requirements:
 
 inputs:
   cancer: string[]
+  platform: string[]
   input_data: File[]
 
 
 outputs:
   predictionouts:
-    doc: tbd
     type: File[]
     outputBinding:
       glob: "*_predictions_for_*.tsv"
@@ -28,8 +28,9 @@ steps:
   stepaklimate:
     in:
       cancer: cancer
+      platform: platform
       input_data: input_data
-    scatter: [cancer, input_data]
+    scatter: [cancer, platform, input_data]
     scatterMethod: dotproduct
     out: [predictionouts]
     run: ../tools/aklimate-pred.cwl


### PR DESCRIPTION
Updated docker image, synapse file id, and documentation

main updates are AKLIMATE now takes argument for model type and can return top, multi, gexp, cnvr or meth